### PR TITLE
Update ws dependency to ^7.4.6 [CVE-2021-32640]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devfolioco/express-ws",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "WebSocket endpoints for Express applications",
   "main": "index",
   "module": "src/index",
@@ -21,13 +21,13 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "esm": "^3.0.84",
-    "ws": "^6.0.0"
+    "ws": "^7.4.6"
   },
   "peerDependencies": {
     "express": "^4.0.0 || ^5.0.0-alpha.1"
   },
   "engines": {
-    "node": ">=4.5.0"
+    "node": ">=8.3.0"
   },
   "directories": {
     "example": "examples"


### PR DESCRIPTION

# Description

Since there was a new major version of ws. Updated the major version of this module since the minimum version of node changed. It wasn't up-to-date (depended on ws@6 which dropped support for Node.js 4.

**Fixes**

Link to the linear issue here
fixes CVE https://nvd.nist.gov/vuln/detail/CVE-2021-32640

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

There's no unit tests so hard to tell if any edge cases are broken but doesn't look like any of the changed features in WS are being used/depended on in this module.

## Changes

- Updated ws dependency
- Bumped minimum version of node to 8.3.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
